### PR TITLE
Add round-tripping with optimized `ntt` version.

### DIFF
--- a/ntt_round_trip.py
+++ b/ntt_round_trip.py
@@ -10,7 +10,7 @@ def cooley_tukey_ntt_opt(inp, n, q, omegas):
     pre-computing the omegas in bit-reversed order.
 
     Requires:
-     `omegas` are provied in bit-reversed order.
+     `omegas` are provided in bit-reversed order.
      `n` is a power of two.
      `q` is equivalent to `1 mod 2n`.
 

--- a/ntt_round_trip.py
+++ b/ntt_round_trip.py
@@ -84,7 +84,7 @@ def gen_phis(omegas, q):
         return pow(x, (q - 1) // 2, q)
 
     def tonelli_shanks(x, q):
-        # Finds the square-root of `x mod q`.
+        # Finds the `sqrt(x) mod q`.
         # Source: https://rosettacode.org/wiki/Tonelli-Shanks_algorithm
         Q = q - 1
         s = 0

--- a/ntt_round_trip.py
+++ b/ntt_round_trip.py
@@ -161,8 +161,8 @@ def round_trip_ntt(n, input_upper_bound):
     ntt_res = cooley_tukey_ntt_opt(a, n, q, br_phis)
 
     inv_phis = inversed(phis, q)
-    inv_phis = get_bit_reversed(inv_phis, n, q)
-    intt_res = gentleman_sande_intt_opt(ntt_res, n, q, inv_phis)
+    br_inv_phis = get_bit_reversed(inv_phis, n, q)
+    intt_res = gentleman_sande_intt_opt(ntt_res, n, q, br_inv_phis)
 
     check_eq(a, intt_res)
 

--- a/ntt_round_trip.py
+++ b/ntt_round_trip.py
@@ -65,7 +65,8 @@ def gentleman_sande_intt_opt(inp, n, q, inv_phis):
         t <<= 1
         m >>= 1
 
-    return [(i // n) % q for i in a]
+    shift_n = int(math.log2(n))
+    return [(i >> shift_n) % q for i in a]
 
 
 def get_bit_reversed(c, n, q):

--- a/ntt_round_trip.py
+++ b/ntt_round_trip.py
@@ -1,16 +1,16 @@
 import random
 import math
 from sympy.ntheory import isprime
-from ntt_utils import check_eq, reverse_bits, gen_omegas, get_omegas_inversed
+from ntt_utils import check_eq, reverse_bits, gen_omegas, inversed
 
 
-def cooley_tukey_ntt_opt(inp, n, q, omegas):
+def cooley_tukey_ntt_opt(inp, n, q, phis):
     """Cooley-Tukey DIT algorithm with an extra optimization.
     We can avoid computing bit reversed order with each call by
-    pre-computing the omegas in bit-reversed order.
+    pre-computing the phis in bit-reversed order.
 
     Requires:
-     `omegas` are provided in bit-reversed order.
+     `phis` are provided in bit-reversed order.
      `n` is a power of two.
      `q` is equivalent to `1 mod 2n`.
 
@@ -30,7 +30,7 @@ def cooley_tukey_ntt_opt(inp, n, q, omegas):
         for i in range(0, m):
             j1 = i * (t << 1)
             j2 = j1 + t - 1
-            S = omegas[m + i]
+            S = phis[m + i]
             for j in range(j1, j2 + 1):
                 U = a[j]
                 V = a[j + t] * S
@@ -40,9 +40,9 @@ def cooley_tukey_ntt_opt(inp, n, q, omegas):
     return a
 
 
-def gentleman_sande_intt_opt(inp, n, q, inv_omegas):
+def gentleman_sande_intt_opt(inp, n, q, inv_phis):
     """Gentleman-Sande INTT butterfly algorithm.
-    Assumes that inverse omegas are stored in bit-reversed order.
+    Assumes that inverse phis are stored in bit-reversed order.
     Reference:
        https://www.microsoft.com/en-us/research/wp-content/
        uploads/2016/05/RLWE-1.pdf
@@ -55,7 +55,7 @@ def gentleman_sande_intt_opt(inp, n, q, inv_omegas):
         h = m // 2
         for i in range(h):
             j2 = j1 + t - 1
-            S = inv_omegas[h + i]
+            S = inv_phis[h + i]
             for j in range(j1, j2 + 1):
                 U = a[j]
                 V = a[j + t]
@@ -68,16 +68,52 @@ def gentleman_sande_intt_opt(inp, n, q, inv_omegas):
     return [(i // n) % q for i in a]
 
 
-def gen_bit_reversed_omegas(n, q):
-    # Generate powers of omega in bit-reversed order.
-    omegas = gen_omegas(n, q)
-
+def get_bit_reversed(c, n, q):
+    cc = c.copy()
     for i in range(n):
         rev_i = reverse_bits(i, n.bit_length() - 1)
         if rev_i > i:
-            omegas[i], omegas[rev_i] = omegas[rev_i], omegas[i]
+            cc[i], cc[rev_i] = cc[rev_i], cc[i]
 
-    return omegas
+    return cc
+
+
+def gen_phis(omegas, q):
+    def legendre(x, q):
+        return pow(x, (q - 1) // 2, q)
+
+    def tonelli_shanks(x, q):
+        # Finds the square-root of `x mod q`.
+        # Source: https://rosettacode.org/wiki/Tonelli-Shanks_algorithm
+        Q = q - 1
+        s = 0
+        while Q % 2 == 0:
+            Q //= 2
+            s += 1
+        if s == 1:
+            return pow(x, (q + 1) // 4, q)
+        for z in range(2, q):
+            if q - 1 == legendre(z, q):
+                break
+        c = pow(z, Q, q)
+        r = pow(x, (Q + 1) // 2, q)
+        t = pow(x, Q, q)
+        m = s
+        t2 = 0
+        while (t - 1) % q != 0:
+            t2 = (t * t) % q
+            for i in range(1, m):
+                if (t2 - 1) % q == 0:
+                    break
+                t2 = (t2 * t2) % q
+            b = pow(c, 1 << (m - i - 1), q)
+            r = (r * b) % q
+            c = (b * b) % q
+            t = (t * c) % q
+            m = i
+        return r
+
+    return [tonelli_shanks(x, q) for x in omegas]
 
 
 def find_modulus(n, min_modulus):
@@ -94,7 +130,7 @@ def find_modulus(n, min_modulus):
     # Pre-condition for minimum modulus.
     assert min_modulus > n
 
-    for k in range(1, n ** 2):
+    for k in range(1, n ** n):
         q = k * 2 * n + 1  # (1)
         if not isprime(q) or q < min_modulus:
             # (2), (3)
@@ -115,18 +151,22 @@ def round_trip_ntt(n, input_upper_bound):
 
     # Pick a sufficiently large minimum modulus to avoid overflow.
     min_modulus = input_upper_bound * n + 1
-
-    a = [random.randint(0, input_upper_bound) for _ in range(n)]
     q = find_modulus(n, min_modulus)
 
-    br_omegas = gen_bit_reversed_omegas(n, q)
-    ntt_res = cooley_tukey_ntt_opt(a, n, q, br_omegas)
+    a = [random.randint(0, input_upper_bound) for _ in range(n)]
+    # q = 12289
 
-    inv_br_omegas = get_omegas_inversed(br_omegas, q)
-    intt_res = gentleman_sande_intt_opt(ntt_res, n, q, inv_br_omegas)
+    omegas = gen_omegas(n, q)
+    phis = gen_phis(omegas, q)
+    br_phis = get_bit_reversed(phis, n, q)
+    ntt_res = cooley_tukey_ntt_opt(a, n, q, br_phis)
+
+    inv_phis = inversed(phis, q)
+    inv_phis = get_bit_reversed(inv_phis, n, q)
+    intt_res = gentleman_sande_intt_opt(ntt_res, n, q, inv_phis)
 
     check_eq(a, intt_res)
 
 
 if __name__ == '__main__':
-    round_trip_ntt(n=1024, input_upper_bound=1000)
+    round_trip_ntt(n=16, input_upper_bound=1000)

--- a/ntt_round_trip.py
+++ b/ntt_round_trip.py
@@ -52,7 +52,7 @@ def gentleman_sande_intt_opt(inp, n, q, inv_phis):
     m = n
     while (m > 1):
         j1 = 0
-        h = m // 2
+        h = m >> 1
         for i in range(h):
             j2 = j1 + t - 1
             S = inv_phis[h + i]
@@ -61,9 +61,9 @@ def gentleman_sande_intt_opt(inp, n, q, inv_phis):
                 V = a[j + t]
                 a[j] = (U + V) % q
                 a[j + t] = ((U - V) * S) % q
-            j1 = j1 + t * 2
-        t *= 2
-        m //= 2
+            j1 += (t << 1)
+        t <<= 1
+        m >>= 1
 
     return [(i // n) % q for i in a]
 
@@ -150,11 +150,10 @@ def round_trip_ntt(n, input_upper_bound):
     """
 
     # Pick a sufficiently large minimum modulus to avoid overflow.
-    min_modulus = input_upper_bound * n + 1
+    min_modulus = input_upper_bound * n
     q = find_modulus(n, min_modulus)
 
     a = [random.randint(0, input_upper_bound) for _ in range(n)]
-    # q = 12289
 
     omegas = gen_omegas(n, q)
     phis = gen_phis(omegas, q)
@@ -169,4 +168,4 @@ def round_trip_ntt(n, input_upper_bound):
 
 
 if __name__ == '__main__':
-    round_trip_ntt(n=16, input_upper_bound=1000)
+    round_trip_ntt(n=1024, input_upper_bound=10)

--- a/ntt_round_trip.py
+++ b/ntt_round_trip.py
@@ -168,4 +168,4 @@ def round_trip_ntt(n, input_upper_bound):
 
 
 if __name__ == '__main__':
-    round_trip_ntt(n=1024, input_upper_bound=10)
+    round_trip_ntt(n=1024, input_upper_bound=1000)

--- a/ntt_round_trip.py
+++ b/ntt_round_trip.py
@@ -1,0 +1,132 @@
+import random
+import math
+from sympy.ntheory import isprime
+from ntt_utils import check_eq, reverse_bits, gen_omegas, get_omegas_inversed
+
+
+def cooley_tukey_ntt_opt(inp, n, q, omegas):
+    """Cooley-Tukey DIT algorithm with an extra optimization.
+    We can avoid computing bit reversed order with each call by
+    pre-computing the omegas in bit-reversed order.
+
+    Requires:
+     `omegas` are provied in bit-reversed order.
+     `n` is a power of two.
+     `q` is equivalent to `1 mod 2n`.
+
+    Reference:
+       https://www.microsoft.com/en-us/research/wp-content/
+       uploads/2016/05/RLWE-1.pdf
+    """
+    a = inp.copy()
+
+    assert q % (2 * n) == 1, f'{q} is not equivalent to 1 mod {2 * n}'
+    assert (n & (n - 1) == 0) and n > 0, f'n: {n} is not a power of 2.'
+
+    t = n
+    m = 1
+    while m < n:
+        t >>= 1
+        for i in range(0, m):
+            j1 = i * (t << 1)
+            j2 = j1 + t - 1
+            S = omegas[m + i]
+            for j in range(j1, j2 + 1):
+                U = a[j]
+                V = a[j + t] * S
+                a[j] = (U + V) % q
+                a[j + t] = (U - V) % q
+        m <<= 1
+    return a
+
+
+def gentleman_sande_intt_opt(inp, n, q, inv_omegas):
+    """Gentleman-Sande INTT butterfly algorithm.
+    Assumes that inverse omegas are stored in bit-reversed order.
+    Reference:
+       https://www.microsoft.com/en-us/research/wp-content/
+       uploads/2016/05/RLWE-1.pdf
+    """
+    a = inp.copy()
+    t = 1
+    m = n
+    while (m > 1):
+        j1 = 0
+        h = m // 2
+        for i in range(h):
+            j2 = j1 + t - 1
+            S = inv_omegas[h + i]
+            for j in range(j1, j2 + 1):
+                U = a[j]
+                V = a[j + t]
+                a[j] = (U + V) % q
+                a[j + t] = ((U - V) * S) % q
+            j1 = j1 + t * 2
+        t *= 2
+        m //= 2
+
+    return [(i // n) % q for i in a]
+
+
+def gen_bit_reversed_omegas(n, q):
+    # Generate powers of omega in bit-reversed order.
+    omegas = gen_omegas(n, q)
+
+    for i in range(n):
+        rev_i = reverse_bits(i, n.bit_length() - 1)
+        if rev_i > i:
+            omegas[i], omegas[rev_i] = omegas[rev_i], omegas[i]
+
+    return omegas
+
+
+def find_modulus(n, min_modulus):
+    """
+    We need to find a number `q` that
+    satisfies the following properties:
+    (1) q = 2 * n * k + 1, for some k.
+    (2) q is a prime number.
+    (3) q >= min_modulus > n
+    (4) q is equivalent to 1 mod 2n.
+
+    By Dirichlet's theorem, this is guaranteed to exist.
+    """
+    # Pre-condition for minimum modulus.
+    assert min_modulus > n
+
+    for k in range(1, n ** 2):
+        q = k * 2 * n + 1  # (1)
+        if not isprime(q) or q < min_modulus:
+            # (2), (3)
+            continue
+        if q % (2 * n) != 1:
+            # (4)
+            continue
+        return q
+
+
+def round_trip_ntt(n, input_upper_bound):
+    """Round trips through ntt and inverse ntt,
+    verifying intt(ntt(a)) = a.
+
+    `n` is the length of our input,
+    and `input_upper_bound` is the maximum value in our input.
+    """
+
+    # Pick a sufficiently large minimum modulus to avoid overflow.
+    min_modulus = input_upper_bound * n + 1
+
+    a = [random.randint(0, input_upper_bound) for _ in range(n)]
+    q = find_modulus(n, min_modulus)
+
+    br_omegas = gen_bit_reversed_omegas(n, q)
+    ntt_res = cooley_tukey_ntt_opt(a, n, q, br_omegas)
+
+    inv_br_omegas = get_omegas_inversed(br_omegas, q)
+    intt_res = gentleman_sande_intt_opt(ntt_res, n, q, inv_br_omegas)
+
+    check_eq(a, intt_res)
+
+
+if __name__ == '__main__':
+    round_trip_ntt(n=1024, input_upper_bound=1000)

--- a/ntt_utils.py
+++ b/ntt_utils.py
@@ -13,20 +13,22 @@ def gen_omegas(n, q):
     # Generate an omega: g^k (mod q) for a generator of the field, g.
     g = primitive_root(q)
     k = (q - 1) // n
+    print(q, k)
     omega = (g ** k) % q
+    assert 0 <= omega and omega < q
 
     # Generate pre-computed omega array (also from Shunning).
     omegas = [1]
     for i in range(n):
-        omegas.append(omegas[i] * omega % q)
+        omegas.append((omegas[i] * omega) % q)
     for i in range(n):
-        assert omegas[n - i] * omegas[i] % q == 1
+        assert (omegas[n - i] * omegas[i]) % q == 1
     omegas = omegas[:n]  # Drop the last, needless value.
 
     return omegas
 
 
-def get_omegas_inversed(omegas, q):
+def inversed(omegas, q):
     def multiplicative_inverse(a, q):
         # We want to find `i` such that `(x * i) mod q == 1`,
         # which which is guaranteed if `x` is a unit of the

--- a/ntt_utils.py
+++ b/ntt_utils.py
@@ -1,0 +1,74 @@
+from sympy.ntheory import isprime, primitive_root
+import math
+
+
+def check_eq(a, b):
+    """Assert that two arrays are equal everywhere."""
+    for i, (x, y) in enumerate(zip(a, b)):
+        assert x == y, f'difference at element {i}: {x}, {y}'
+    print('ok!')
+
+
+def gen_omegas(n, q):
+    # Generate an omega: g^k (mod q) for a generator of the field, g.
+    g = primitive_root(q)
+    k = (q - 1) // n
+    omega = (g ** k) % q
+
+    # Generate pre-computed omega array (also from Shunning).
+    omegas = [1]
+    for i in range(n):
+        omegas.append(omegas[i] * omega % q)
+    for i in range(n):
+        assert omegas[n - i] * omegas[i] % q == 1
+    omegas = omegas[:n]  # Drop the last, needless value.
+
+    return omegas
+
+
+def get_omegas_inversed(omegas, q):
+    def multiplicative_inverse(a, q):
+        # We want to find `i` such that `(x * i) mod q == 1`,
+        # which which is guaranteed if `x` is a unit of the
+        # multiplicative group under `q`.
+        #
+        # Reference:
+        # https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
+        prime = q
+        Y = 0
+        X = 1
+        if a == 1:
+            return 0
+        while a > 1:
+            quotient = a // q
+            t = q
+            q = a % q
+            a = t
+            t = Y
+            Y = X - quotient * Y
+            X = t
+        return X if X >= 0 else X + prime
+
+    return [multiplicative_inverse(x, q) for x in omegas]
+
+
+def reverse_bits(number, bit_length):
+    # Reverses the bits of `number` up to `bit_length`.
+    reversed = 0
+    for i in range(0, bit_length):
+        if (number >> i) & 1: reversed |= 1 << (bit_length - 1 - i)
+    return reversed
+
+
+def find_prime(n):
+    """Pick a prime number k*n+1 for some k."""
+    for k in range(1, 100):
+        p = k * n + 1
+        if isprime(p):
+            return p
+    assert False, 'prime not found!!!1111one'
+
+
+def _data(arr, bitwidth=32):
+    """Make a FuTIL-ready JSON data dict."""
+    return {'data': arr, 'bitwidth': bitwidth}

--- a/ntt_utils.py
+++ b/ntt_utils.py
@@ -13,7 +13,6 @@ def gen_omegas(n, q):
     # Generate an omega: g^k (mod q) for a generator of the field, g.
     g = primitive_root(q)
     k = (q - 1) // n
-    print(q, k)
     omega = (g ** k) % q
     assert 0 <= omega and omega < q
 

--- a/nttstuff.py
+++ b/nttstuff.py
@@ -1,18 +1,9 @@
 from sympy.discrete.transforms import ntt
-from sympy.ntheory import isprime, primitive_root
 import random
 import math
 import json
 import argparse
-
-
-def find_prime(n):
-    """Pick a prime number k*n+1 for some k."""
-    for k in range(1, 100):
-        p = k * n + 1
-        if isprime(p):
-            return p
-    assert False, 'prime not found!!!1111one'
+from ntt_utils import check_eq, _data, find_prime, reverse_bits, gen_omegas
 
 
 def naive_ntt(inp, P, omegas):
@@ -53,43 +44,6 @@ def cooley_tukey_ntt(inp, P, omegas):
         M = M * 2
 
     return ret
-
-
-def _data(arr, bitwidth=32):
-    """Make a FuTIL-ready JSON data dict."""
-    return {'data': arr, 'bitwidth': bitwidth}
-
-
-def check_eq(a, b):
-    """Assert that two arrays are equal everywhere."""
-    for i, (x, y) in enumerate(zip(a, b)):
-        assert x == y, f'difference at element {i}: {x}, {y}'
-    print('ok!')
-
-
-def gen_omegas(n, p):
-    # Generate an omega: g^k (mod p) for a generator of the field, g.
-    g = primitive_root(p)
-    k = (p - 1) // n
-    omega = (g ** k) % p
-
-    # Generate pre-computed omega array (also from Shunning).
-    omegas = [1]
-    for i in range(n):
-        omegas.append(omegas[i] * omega % p)
-    for i in range(n):
-        assert omegas[n - i] * omegas[i] % p == 1
-    omegas = omegas[:n]  # Drop the last, needless value.
-
-    return omegas
-
-
-def reverse_bits(number, bit_length):
-    # Reverses the bits of `number` up to `bit_length`.
-    reversed = 0
-    for i in range(0, bit_length):
-        if (number >> i) & 1: reversed |= 1 << (bit_length - 1 - i)
-    return reversed
 
 
 def run_ntt(n, dump_input, dump_output, indata=None):


### PR DESCRIPTION
I've added a second file for verifying correctness with round-tripping. 

I've implemented, the first-level optimized version of the algorithm in:
[Speeding up the Number Theoretic Transform for Faster Ideal Lattice-Based Cryptography](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/05/RLWE-1.pdf)

This mainly takes out the bit reversal step in the forward NTT, by using bit reversed phi values, and GS-INTT. 

One thing to note, the rest of the paper discusses optimizations for a specific criteria, i.e. `q=12289` and `n={256, 512, 1024}`. Reasons for this, as described by the paper:

> Many state of-the-art instantiations of R-LWE-based cryptography choose n and q as above in order to harness the efficiency of the NTT; for example, the BLISS signature implementations (I-IV) set n = 512 and q = 12289 [12] and the fastest R-LWE-based key exchange implementation to date sets n = 1024 and q = 12289 [2].

These optimizations focus on the relationship between `q` and `n` that produce a small `k` value (since `q = k*n + 1`), which allows for some trickery to remove modulo operators at certain stages.

So next steps might include:
1. Looking into these optimizations. I think this should definitely reduce cycle count.
2. Implementing the forward stage of this in Dahlia, with pre-computed phis.
